### PR TITLE
HFP-3902 Allow empty custom endscreen title field

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "description": "description",
   "majorVersion": 1,
   "minorVersion": 8,
-  "patchVersion": 5,
+  "patchVersion": 6,
   "runnable": 1,
   "embedTypes": [
     "iframe"

--- a/semantics.json
+++ b/semantics.json
@@ -214,6 +214,7 @@
                   "name": "title",
                   "type": "text",
                   "label": "Feedback title",
+                  "optional": true,
                   "widget": "html",
                   "enterMode": "p",
                   "tags": [


### PR DESCRIPTION
When merged in, will allow to empty a custom endscreen title field after it was filled previously.