### PR TITLE
AU-7086 Fix resize loop

### DIFF
--- a/src/scripts/libraryScreen.js
+++ b/src/scripts/libraryScreen.js
@@ -152,7 +152,9 @@ export default class LibraryScreen extends H5P.EventDispatcher {
           // Make the library resize then make the wrapper resize to the new library height
           addResizeListener(this.currentLibraryElement, () => {
             this.handleLibraryResize();
+            this.parent.bubblingUpwards = true;
             this.parent.trigger('resize');
+            this.parent.bubblingUpwards = false;
           });
         }, 100);
       }


### PR DESCRIPTION
Parent should not re-resize children when it was a child that initiated the original resize.