### PR TITLE
HFP-4332 Fix as subcontent

### DIFF
--- a/src/scripts/h5p-branching-scenario.js
+++ b/src/scripts/h5p-branching-scenario.js
@@ -806,7 +806,9 @@ export default class BranchingScenario extends H5P.EventDispatcher {
       this.container.append(this.endScreens[endScreen.contentId].getElement());
     });
 
-    this.restoreView(this.extras.previousState);
+    window.requestAnimationFrame(() => {
+      this.restoreView(this.extras.previousState);
+    });
   }
 
   /**

--- a/src/styles/h5p-branching-scenario.scss
+++ b/src/styles/h5p-branching-scenario.scss
@@ -71,6 +71,10 @@
   100% { -webkit-transform: translateX(0%); }
 }
 
+.h5p-branching-scenario {
+  overflow: hidden;
+}
+
 .h5p-branching-scenario h1, h2, h3, h4, h5 {
   font-weight: normal;
 }


### PR DESCRIPTION
When merged in, will fix issues that prevent using Branching Scenario as subcontent.

Current issues as subcontent:
- Slides overflow the container when progressing, because Branching Scenario relies on `overflow: hidden` of H5P container.
- Recreating the previous state fails, because the called methods query the DOM before the content is attached to the page.